### PR TITLE
Landing Code

### DIFF
--- a/rosplane/src/controller_example.cpp
+++ b/rosplane/src/controller_example.cpp
@@ -28,7 +28,7 @@ void controller_example::control(const params_s &params, const input_s &input, o
     ROS_FATAL_ONCE("LANDING");
 		output.delta_t = 0.0;
 		output.theta_c = 0.0*3.14159/180.0;
-		if(input.h < 10.0){
+		if(input.h < 1.0){
 			output.delta_a = roll_hold(0.0, input.phi, input.p, params, input.Ts);
 		}
 	}

--- a/rosplane/src/odroid_gpio.cpp
+++ b/rosplane/src/odroid_gpio.cpp
@@ -1,5 +1,5 @@
 #include <odroid_gpio.h>
-#include <wiringPi.h>
+//#include <wiringPi.h>
 
 namespace rosplane
 {
@@ -11,13 +11,13 @@ OdroidGPIO::OdroidGPIO():
 }
 bool OdroidGPIO::gpio0high(std_srvs::Trigger::Request &req, std_srvs::Trigger:: Response &res)
 {
-  digitalWrite(0,HIGH);
+  //digitalWrite(0,HIGH);
   res.success = true;
   return true;
 }
 bool OdroidGPIO::gpio0low(std_srvs::Trigger::Request &req, std_srvs::Trigger:: Response &res)
 {
-  digitalWrite(0,LOW);
+  //digitalWrite(0,LOW);
   res.success = true;
   return true;
 }
@@ -27,9 +27,9 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "odroid_gpio");
 
   // setup pins
-  wiringPiSetup ();
-  pinMode (0, OUTPUT);
-  // digitalWrite(0, HIGH);
+  //wiringPiSetup ();
+  //pinMode (0, OUTPUT);
+  //digitalWrite(0, LOW);
 
   // run ros
   rosplane::OdroidGPIO obj;

--- a/rosplane/src/odroid_gpio.cpp
+++ b/rosplane/src/odroid_gpio.cpp
@@ -1,5 +1,5 @@
 #include <odroid_gpio.h>
-//#include <wiringPi.h>
+#include <wiringPi.h>
 
 namespace rosplane
 {
@@ -11,13 +11,13 @@ OdroidGPIO::OdroidGPIO():
 }
 bool OdroidGPIO::gpio0high(std_srvs::Trigger::Request &req, std_srvs::Trigger:: Response &res)
 {
-  //digitalWrite(0,HIGH);
+  digitalWrite(0,HIGH);
   res.success = true;
   return true;
 }
 bool OdroidGPIO::gpio0low(std_srvs::Trigger::Request &req, std_srvs::Trigger:: Response &res)
 {
-  //digitalWrite(0,LOW);
+  digitalWrite(0,LOW);
   res.success = true;
   return true;
 }
@@ -27,9 +27,9 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "odroid_gpio");
 
   // setup pins
-  //wiringPiSetup ();
-  //pinMode (0, OUTPUT);
-  //digitalWrite(0, LOW);
+  wiringPiSetup ();
+  pinMode (0, OUTPUT);
+  // digitalWrite(0, HIGH);
 
   // run ros
   rosplane::OdroidGPIO obj;


### PR DESCRIPTION
The original code had the plane level out and fly with no power when under 10m which creates a huge variability in where the plane lands. This changes the height to 1 m which should allow for a more precise end landing location.