### PR TITLE
Inertial Sense estimator

### DIFF
--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -70,13 +70,6 @@ add_executable(ins_estimator
 add_dependencies(ins_estimator ${catkin_EXPORTED_TARGETS})
 target_link_libraries(ins_estimator ${catkin_LIBRARIES})
 
-
-add_executable(ins_estimator
-            src/ins_estimator_base.cpp
-            src/ins_estimator_example.cpp)
-add_dependencies(ins_estimator ${catkin_EXPORTED_TARGETS})
-target_link_libraries(ins_estimator ${catkin_LIBRARIES})
-
 ## Declare a C++ executable
 add_executable(rosplane_path_follower
             src/path_follower_example.cpp

--- a/rosplane/CMakeLists.txt
+++ b/rosplane/CMakeLists.txt
@@ -64,6 +64,12 @@ add_executable(rosplane_estimator
 add_dependencies(rosplane_estimator ${catkin_EXPORTED_TARGETS})
 target_link_libraries(rosplane_estimator ${catkin_LIBRARIES})
 
+add_executable(ins_estimator
+	src/ins_estimator_base.cpp
+	src/ins_estimator_example.cpp)
+add_dependencies(ins_estimator ${catkin_EXPORTED_TARGETS})
+target_link_libraries(ins_estimator ${catkin_LIBRARIES})
+
 
 add_executable(ins_estimator
             src/ins_estimator_base.cpp

--- a/rosplane/include/ins_estimator_base.h
+++ b/rosplane/include/ins_estimator_base.h
@@ -1,0 +1,160 @@
+/**
+ * @file ins_estimator_base.h
+ *
+ * Inertial sense estimator
+ *
+ */
+
+#ifndef ESTIMATOR_BASE_H
+#define ESTIMATOR_BASE_H
+
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <rosplane_msgs/State.h>
+// #include <rosflight_msgs/GPS.h>
+#include <inertial_sense/GPS.h>
+#include <sensor_msgs/Imu.h>
+#include <rosflight_msgs/Barometer.h>
+#include <rosflight_msgs/Airspeed.h>
+#include <rosflight_msgs/Status.h>
+#include <math.h>
+#include <Eigen/Eigen>
+
+#include <numeric> // for 18.04
+
+#define EARTH_RADIUS 6378145.0f
+#define FILTER_LENGTH 16
+
+namespace rosplane
+{
+
+
+class ins_estimator_base
+{
+public:
+  ins_estimator_base();
+
+protected:
+
+  struct input_s
+  {
+    float gyro_x;
+    float gyro_y;
+    float gyro_z;
+    float accel_x;
+    float accel_y;
+    float accel_z;
+    float static_pres;
+    float diff_pres;
+    bool gps_new;
+    float gps_n;
+    float gps_e;
+    float gps_h;
+    float gps_Vg;
+    float gps_course;
+    bool status_armed;
+    bool armed_init;
+  };
+
+  struct output_s
+  {
+    float pn;
+    float pe;
+    float h;
+    float Va;
+    float alpha;
+    float beta;
+    float phi;
+    float theta;
+    float psi;
+    float chi;
+    float p;
+    float q;
+    float r;
+    float Vg;
+    float wn;
+    float we;
+  };
+
+  struct params_s
+  {
+    double gravity;
+    double rho;
+    double sigma_accel;
+    double sigma_n_gps;
+    double sigma_e_gps;
+    double sigma_Vg_gps;
+    double sigma_course_gps;
+    double Ts;
+  };
+
+  virtual void estimate(const struct params_s &params, const struct input_s &input, struct output_s &output) = 0;
+
+private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+  ros::Publisher vehicle_state_pub_;
+  ros::Subscriber gps_sub_;
+  ros::Subscriber imu_sub_;
+  ros::Subscriber baro_sub_;
+  ros::Subscriber airspeed_sub_;
+  ros::Subscriber status_sub_;
+  ros::Subscriber inertial_sense_sub_;
+
+  void updateAltitudeAndAirspeed(const ros::TimerEvent &);
+  void update(const ros::TimerEvent &);
+  // void gpsCallback(const rosflight_msgs::GPS &msg);
+  void gpsCallback(const inertial_sense::GPS &msg);
+  void imuCallback(const sensor_msgs::Imu &msg);
+  void baroAltCallback(const rosflight_msgs::Barometer &msg);
+  void airspeedCallback(const rosflight_msgs::Airspeed &msg);
+  void statusCallback(const rosflight_msgs::Status &msg);
+  void inertialSenseCallback(const nav_msgs::Odometry &msg_in);
+  void updateAirspeed(const ros::TimerEvent &);
+	void filterAirspeed(float &Va);
+
+  double update_rate_;
+  ros::Timer update_timer_;
+  std::string gps_topic_;
+  std::string imu_topic_;
+  std::string baro_topic_;
+  std::string airspeed_topic_;
+  std::string status_topic_;
+
+  float lpf_static_base_;
+  float lpf_diff_base_;
+  float Ve_base_;
+  float Vn_base_;
+  float alpha1_base_;
+  float Vahat_;
+  float hhat_;
+	float filter_taps_[FILTER_LENGTH] = {0.00970489747784546,	0.0145629416394102,	0.0282895307460455,	0.0485513149017384,
+		0.0718604720902472,	0.0941826681792385,	0.111642954778265,	0.121205220187210,	0.121205220187210,
+		0.111642954778265,	0.0941826681792385,	0.0718604720902472,	0.0485513149017384,	0.0282895307460455,
+		0.0145629416394102,	0.00970489747784546};
+	float Va_history_[FILTER_LENGTH];
+  bool gps_new_;
+  bool gps_init_;
+  double init_lat_;       /**< Initial latitude in degrees */
+  double init_lon_;       /**< Initial longitude in degrees */
+  float init_alt_;        /**< Initial altitude in meters above MSL  */
+  bool armed_first_time_; /**< Arm before starting estimation  */
+  bool baro_init_;        /**< Initial barometric pressure */
+  float init_static_;     /**< Initial static pressure (mbar)  */
+  int baro_count_;        /**< Used to grab the first set of baro measurements */
+  std::vector<float> init_static_vector_; /**< Used to grab the first set of baro measurements */
+
+  struct params_s                 params_;
+  struct input_s                  input_;
+
+
+  double height_offset_;
+  double calibrate_to_this_;
+  double calibration_sum_;
+  int avg_this_many_;
+  int counted_this_many_ ;
+};
+
+} //end namespace
+
+#endif // ESTIMATOR_BASE_H

--- a/rosplane/include/ins_estimator_base.h
+++ b/rosplane/include/ins_estimator_base.h
@@ -153,6 +153,10 @@ private:
   double calibration_sum_;
   int avg_this_many_;
   int counted_this_many_ ;
+
+  double lat_ref_{0.};
+  double lon_ref_{0.};
+  double alt_ref_{0.};
 };
 
 } //end namespace

--- a/rosplane/include/ins_estimator_example.h
+++ b/rosplane/include/ins_estimator_example.h
@@ -1,0 +1,73 @@
+#ifndef ESTIMATOR_EXAMPLE_H
+#define ESTIMATOR_EXAMPLE_H
+
+#include "ins_estimator_base.h"
+
+#include <math.h>
+#include <Eigen/Eigen>
+
+namespace rosplane
+{
+
+class ins_estimator_example : public ins_estimator_base
+{
+public:
+  ins_estimator_example();
+
+private:
+  virtual void estimate(const params_s &params, const input_s &input, output_s &output);
+
+//    float gps_n_old_;
+//    float gps_e_old_;
+//    float gps_Vg_old_;
+//    float gps_course_old_;
+
+  double lpf_a_;
+  float alpha_;
+  float alpha1_;
+  int N_;
+
+  float lpf_gyro_x_;
+  float lpf_gyro_y_;
+  float lpf_gyro_z_;
+  float lpf_static_;
+  float lpf_diff_;
+  float lpf_accel_x_;
+  float lpf_accel_y_;
+  float lpf_accel_z_;
+
+  float phat_;
+  float qhat_;
+  float rhat_;
+  float Vwhat_;
+  float phihat_;
+  float thetahat_;
+  float psihat_;
+  Eigen::Vector2f xhat_a_; // 2
+  Eigen::Matrix2f P_a_;  // 2x2
+
+  Eigen::VectorXf xhat_p_; // 7
+  Eigen::MatrixXf P_p_;  // 7x7
+
+  Eigen::Matrix2f Q_a_;  // 2x2
+  float R_accel_;
+  Eigen::Vector2f f_a_;  // 2
+  Eigen::Matrix2f A_a_;  // 2x2
+  float h_a_;
+  Eigen::Vector2f C_a_;  // 2
+  Eigen::Vector2f L_a_;  // 2
+
+  Eigen::MatrixXf Q_p_;  // 7x7
+  Eigen::MatrixXf R_p_;  // 6x6
+  Eigen::VectorXf f_p_;  // 7
+  Eigen::MatrixXf A_p_;  // 7x7
+  float h_p_;
+  Eigen::VectorXf C_p_;  // 7
+  Eigen::VectorXf L_p_;  // 7
+
+  void check_xhat_a();
+
+};
+} //end namespace
+
+#endif // ESTIMATOR_EXAMPLE_H

--- a/rosplane/src/ins_estimator_base.cpp
+++ b/rosplane/src/ins_estimator_base.cpp
@@ -16,35 +16,19 @@ ins_estimator_base::ins_estimator_base():
   bool use_inertial_sense;
   std::string inertial_sense_topic;
   nh_private_.param<std::string>("inertial_sense_topic", inertial_sense_topic, "ins");
-  nh_private_.param<std::string>("gps_topic", gps_topic_, "gps");
   nh_private_.param<std::string>("imu_topic", imu_topic_, "imu/data");
   nh_private_.param<std::string>("baro_topic", baro_topic_, "baro");
   nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "airspeed");
-  nh_private_.param<std::string>("status_topic", status_topic_, "status");
   nh_private_.param<std::string>("status_topic", status_topic_, "status");
   nh_private_.param<double>("update_rate", update_rate_, 100.0);
   params_.Ts = 1.0f/update_rate_;
   params_.gravity = 9.8;
   nh_private_.param<double>("rho", params_.rho, 1.225);
-  nh_private_.param<double>("sigma_accel", params_.sigma_accel, 0.0245);
-  nh_private_.param<double>("sigma_n_gps", params_.sigma_n_gps, 0.21);
-  nh_private_.param<double>("sigma_e_gps", params_.sigma_e_gps, 0.21);
-  nh_private_.param<double>("sigma_Vg_gps", params_.sigma_Vg_gps, 0.0500);
-  nh_private_.param<double>("sigma_couse_gps", params_.sigma_course_gps, 0.0045);
   nh_private_.param<bool>("use_inertial_sense", use_inertial_sense, false);
 
-  if (use_inertial_sense)
-  {
-    inertial_sense_sub_ = nh_.subscribe(inertial_sense_topic, 1, &ins_estimator_base::inertialSenseCallback, this);
-    update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &ins_estimator_base::updateAltitudeAndAirspeed, this);
-    ROS_INFO("[Estimator Node] Using InertialSense.");
-  }
-  else
-  {
-    gps_sub_ = nh_.subscribe(gps_topic_, 10, &ins_estimator_base::gpsCallback, this);
-    imu_sub_ = nh_.subscribe(imu_topic_, 10, &ins_estimator_base::imuCallback, this);
-    update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &ins_estimator_base::update, this);
-  }
+  inertial_sense_sub_ = nh_.subscribe(inertial_sense_topic, 1, &ins_estimator_base::inertialSenseCallback, this);
+  update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &ins_estimator_base::updateAltitudeAndAirspeed, this);
+  ROS_INFO("[Estimator Node] Using InertialSense.");
 
   baro_sub_ = nh_.subscribe(baro_topic_, 10, &ins_estimator_base::baroAltCallback, this);
   status_sub_ = nh_.subscribe(status_topic_, 1, &ins_estimator_base::statusCallback, this);

--- a/rosplane/src/ins_estimator_base.cpp
+++ b/rosplane/src/ins_estimator_base.cpp
@@ -1,0 +1,409 @@
+#include "ins_estimator_base.h"
+#include "ins_estimator_example.h"
+
+namespace rosplane
+{
+
+ins_estimator_base::ins_estimator_base():
+  nh_(ros::NodeHandle()),
+  nh_private_(ros::NodeHandle("~"))
+{
+  height_offset_     = 0.0;
+  calibrate_to_this_ = -6.7056;
+  calibration_sum_   = 0.0;
+  avg_this_many_     = 30;
+  counted_this_many_ = 0;
+  bool use_inertial_sense;
+  std::string inertial_sense_topic;
+  nh_private_.param<std::string>("inertial_sense_topic", inertial_sense_topic, "ins");
+  nh_private_.param<std::string>("gps_topic", gps_topic_, "gps");
+  nh_private_.param<std::string>("imu_topic", imu_topic_, "imu/data");
+  nh_private_.param<std::string>("baro_topic", baro_topic_, "baro");
+  nh_private_.param<std::string>("airspeed_topic", airspeed_topic_, "airspeed");
+  nh_private_.param<std::string>("status_topic", status_topic_, "status");
+  nh_private_.param<std::string>("status_topic", status_topic_, "status");
+  nh_private_.param<double>("update_rate", update_rate_, 100.0);
+  params_.Ts = 1.0f/update_rate_;
+  params_.gravity = 9.8;
+  nh_private_.param<double>("rho", params_.rho, 1.225);
+  nh_private_.param<double>("sigma_accel", params_.sigma_accel, 0.0245);
+  nh_private_.param<double>("sigma_n_gps", params_.sigma_n_gps, 0.21);
+  nh_private_.param<double>("sigma_e_gps", params_.sigma_e_gps, 0.21);
+  nh_private_.param<double>("sigma_Vg_gps", params_.sigma_Vg_gps, 0.0500);
+  nh_private_.param<double>("sigma_couse_gps", params_.sigma_course_gps, 0.0045);
+  nh_private_.param<bool>("use_inertial_sense", use_inertial_sense, false);
+
+  if (use_inertial_sense)
+  {
+    inertial_sense_sub_ = nh_.subscribe(inertial_sense_topic, 1, &ins_estimator_base::inertialSenseCallback, this);
+    update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &ins_estimator_base::updateAltitudeAndAirspeed, this);
+    ROS_INFO("[Estimator Node] Using InertialSense.");
+  }
+  else
+  {
+    gps_sub_ = nh_.subscribe(gps_topic_, 10, &ins_estimator_base::gpsCallback, this);
+    imu_sub_ = nh_.subscribe(imu_topic_, 10, &ins_estimator_base::imuCallback, this);
+    update_timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &ins_estimator_base::update, this);
+  }
+
+  baro_sub_ = nh_.subscribe(baro_topic_, 10, &ins_estimator_base::baroAltCallback, this);
+  status_sub_ = nh_.subscribe(status_topic_, 1, &ins_estimator_base::statusCallback, this);
+  airspeed_sub_ = nh_.subscribe(airspeed_topic_, 10, &ins_estimator_base::airspeedCallback, this);
+  vehicle_state_pub_ = nh_.advertise<rosplane_msgs::State>("state", 10);
+  init_static_ = 0;
+  baro_count_ = 0;
+  hhat_ = 0;
+  armed_first_time_ = false;
+
+  float lpf_a1   = 8.0;
+  lpf_diff_base_ = 0.0f;
+  lpf_static_base_ = 0.0f;
+  Ve_base_ = 0.0f;
+  Vn_base_ = 0.0f;
+  alpha1_base_   = exp(-lpf_a1*params_.Ts);
+}
+void ins_estimator_base::inertialSenseCallback(const nav_msgs::Odometry &msg_in)
+{
+  // CHANGE ALTITUDE STUFF TO TAKE hhat_
+  // if (counted_this_many_ <= avg_this_many_)
+  // {
+  //   calibration_sum_ += msg_in.pose.pose.position.z;
+  //   counted_this_many_++;
+  //   if (counted_this_many_ == avg_this_many_)
+  //   {
+  //     height_offset_ = calibrate_to_this_ - calibration_sum_/counted_this_many_; // avg + height_offset_ = calibrate_to_this_;
+  //   }
+  // }
+  rosplane_msgs::State msg;
+  msg.header.stamp    = ros::Time::now();
+  msg.header.frame_id = 1; // Denotes global frame
+
+  msg.position[0]     = msg_in.pose.pose.position.x;
+  msg.position[1]     = msg_in.pose.pose.position.y;
+  msg.position[2]     = -hhat_;
+  // msg.position[2]     = msg_in.pose.pose.position.z + height_offset_;
+
+  if (gps_init_)
+  {
+    msg.initial_lat   = init_lat_;
+    msg.initial_lon   = init_lon_;
+    msg.initial_alt   = init_alt_;
+  }
+
+  // Convert quaterion to roll pitch and yaw
+  float e0       = msg_in.pose.pose.orientation.w;
+  float e1       = msg_in.pose.pose.orientation.x;
+  float e2       = msg_in.pose.pose.orientation.y;
+  float e3       = msg_in.pose.pose.orientation.z;
+  float phi      = atan2(2.0f*(e0*e1 + e2*e3),(e0*e0 + e3*e3 - e1*e1 - e2*e2));
+  float theta    = asin(2.0f*(e0*e2 - e1*e3));
+  float psi      = atan2(2.0f*(e0*e3 + e1*e2),(e0*e0 + e1*e1 - e2*e2 - e3*e3));
+  float c_theta  = cosf(theta);
+  float s_theta  = sinf(theta);
+  float c_psi    = cosf(psi);
+  float s_psi    = sinf(psi);
+  float c_phi    = cosf(phi);
+  float s_phi    = sinf(phi);
+
+  float R[2][3];
+  R[0][0]        = c_theta*c_psi;
+  R[0][1]        = s_phi*s_theta*c_psi - c_phi*s_psi;
+  R[0][2]        = c_phi*s_theta*c_psi + s_phi*s_psi;
+  R[1][0]        = c_theta*s_psi;
+  R[1][1]        = s_phi*s_theta*s_psi;
+  R[1][2]        = c_phi*s_theta*s_psi - s_phi*c_psi;
+  float u        = msg_in.twist.twist.linear.x;
+  float v        = msg_in.twist.twist.linear.y;
+  float w        = msg_in.twist.twist.linear.z;
+  float Vn       = R[0][0]*u + R[0][1]*v + R[0][2]*w;
+  float Ve       = R[1][0]*u + R[1][1]*v + R[1][2]*w;
+
+  msg.Va         = Vahat_;
+  msg.alpha      = 0.0;
+  msg.beta       = 0.0;
+  msg.phi        = phi;
+  msg.theta      = theta;
+  msg.psi        = psi;
+  // low pass filter Ve and Vn for course angle
+  Ve_base_ = alpha1_base_ * Ve_base_ + (1.0f - alpha1_base_) * Ve;
+  Vn_base_ = alpha1_base_ * Vn_base_ + (1.0f - alpha1_base_) * Vn;
+  msg.chi        = atan2f(Ve_base_, Vn_base_);
+  msg.p          = msg_in.twist.twist.angular.x;
+  msg.q          = msg_in.twist.twist.angular.y;
+  msg.r          = msg_in.twist.twist.angular.z;
+  msg.Vg         = sqrtf(Vn_base_*Vn_base_ + Ve_base_*Ve_base_);
+  msg.wn         = 0.0;
+  msg.we         = 0.0;
+  msg.quat_valid = false;
+
+  msg.psi_deg    = fmod(msg.psi, 2.0*M_PI)*180/M_PI; //-360 to 360
+  msg.psi_deg   += (msg.psi_deg < -180 ? 360 : 0);
+  msg.psi_deg   -= (msg.psi_deg > 180 ? 360 : 0);
+  msg.chi_deg    = fmod(msg.chi, 2.0*M_PI)*180/M_PI; //-360 to 360
+  msg.chi_deg   += (msg.chi_deg < -180 ? 360 : 0);
+  msg.chi_deg   -= (msg.chi_deg > 180 ? 360 : 0);
+
+  vehicle_state_pub_.publish(msg);
+}
+void ins_estimator_base::updateAirspeed(const ros::TimerEvent &)
+{
+  // Low Pass filter airspeed
+  lpf_diff_base_ = alpha1_base_*lpf_diff_base_ + (1.0f - alpha1_base_)*input_.diff_pres;
+  if (lpf_diff_base_ <= 0.00001)
+    lpf_diff_base_ = 0.000001;
+  //Vahat_ = sqrtf(2.0f/params_.rho*lpf_diff_base_);
+  if (input_.diff_pres < 0.0f)
+    input_.diff_pres = 0.0f;
+  Vahat_ = sqrtf(2.0f/params_.rho*input_.diff_pres);
+  ins_estimator_base::filterAirspeed(Vahat_);
+}
+void ins_estimator_base::filterAirspeed(float &Va){
+	for(int NN = FILTER_LENGTH-1; NN > 0; NN--){
+		Va_history_[NN] = Va_history_[NN-1];
+	}
+	Va_history_[0] = Va;
+	Va = 0;
+	for(int NN = 0; NN < FILTER_LENGTH; NN++){
+		Va += Va_history_[NN]*filter_taps_[NN];
+	}
+}
+
+// Just estimate altitude and airspeed since ROSPlane does that better
+// than the Inertial Sense
+void ins_estimator_base::updateAltitudeAndAirspeed(const ros::TimerEvent &)
+{
+  // UPDATE ALTITUDE
+  // Low pass filter static pressure sensor and invert to estimate altitude
+  lpf_static_base_ = alpha1_base_ * lpf_static_base_ + (1.0f - alpha1_base_)*input_.static_pres;
+  hhat_ = lpf_static_base_ / params_.rho / params_.gravity;
+  if (hhat_ < 0.0f)
+    hhat_ = 0.0f;
+
+  // UPDATE AIRSPEED
+  // Low Pass filter airspeed
+  // lpf_diff_base_ = alpha1_base_*lpf_diff_base_ + (1.0f - alpha1_base_)*input_.diff_pres;
+  // if (lpf_diff_base_ <= 0.00001)
+  //   lpf_diff_base_ = 0.000001;
+  //Vahat_ = sqrtf(2.0f/params_.rho*lpf_diff_base_);
+  if (input_.diff_pres < 0.0f)
+    input_.diff_pres = 0.0f;
+  Vahat_ = sqrtf(2.0f/params_.rho*input_.diff_pres);
+  ins_estimator_base::filterAirspeed(Vahat_); // they're doing this instead of using lpf_diff_base_
+}
+
+void ins_estimator_base::update(const ros::TimerEvent &)
+{
+  struct output_s output;
+
+  if (armed_first_time_)
+  {
+    estimate(params_, input_, output);
+  }
+  else
+  {
+    output.pn = output.pe = output.h = 0;
+    output.phi = output.theta = output.psi = 0;
+    output.alpha = output.beta = output.chi = 0;
+    output.p = output.q = output.r = 0;
+    output.Va = 0;
+  }
+
+  input_.gps_new = false;
+
+  rosplane_msgs::State msg;
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = 1; // Denotes global frame
+
+  msg.position[0] = output.pn;
+  msg.position[1] = output.pe;
+  msg.position[2] = -output.h;
+  if (gps_init_)
+  {
+    msg.initial_lat = init_lat_;
+    msg.initial_lon = init_lon_;
+    msg.initial_alt = init_alt_;
+  }
+  msg.Va = output.Va;
+  msg.alpha = output.alpha;
+  msg.beta = output.beta;
+  msg.phi = output.phi;
+  msg.theta = output.theta;
+  msg.psi = output.psi;
+  msg.chi = output.chi;
+  msg.p = output.p;
+  msg.q = output.q;
+  msg.r = output.r;
+  msg.Vg = output.Vg;
+  msg.wn = output.wn;
+  msg.we = output.we;
+  msg.quat_valid = false;
+
+  msg.psi_deg = fmod(output.psi, 2.0*M_PI)*180/M_PI; //-360 to 360
+  msg.psi_deg += (msg.psi_deg < -180 ? 360 : 0);
+  msg.psi_deg -= (msg.psi_deg > 180 ? 360 : 0);
+  msg.chi_deg = fmod(output.chi, 2.0*M_PI)*180/M_PI; //-360 to 360
+  msg.chi_deg += (msg.chi_deg < -180 ? 360 : 0);
+  msg.chi_deg -= (msg.chi_deg > 180 ? 360 : 0);
+
+  vehicle_state_pub_.publish(msg);
+}
+
+void ins_estimator_base::gpsCallback(const inertial_sense::GPS &msg)
+{
+  if (msg.fix_type == 0 || msg.num_sat < 4 || !std::isfinite(msg.latitude))
+  {
+    input_.gps_new = false;
+    return;
+  }
+  if (!gps_init_)
+  {
+    gps_init_ = true;
+    init_alt_ = msg.altitude;
+    init_lat_ = msg.latitude;
+    init_lon_ = msg.longitude;
+  }
+  else
+  {
+    input_.gps_n = EARTH_RADIUS*(msg.latitude - init_lat_)*M_PI/180.0;
+    input_.gps_e = EARTH_RADIUS*cos(init_lat_*M_PI/180.0)*(msg.longitude - init_lon_)*M_PI/180.0;
+    input_.gps_h = msg.altitude - init_alt_;
+    input_.gps_Vg = msg.ground_speed_3d;
+    if (msg.ground_speed_3d > 0.3)
+      input_.gps_course = msg.course;
+    input_.gps_new = true;
+  }
+}
+
+// void ins_estimator_base::gpsCallback(const rosflight_msgs::GPS &msg)
+// {
+//   if (msg.fix != true || msg.NumSat < 4 || !std::isfinite(msg.latitude))
+//   {
+//     input_.gps_new = false;
+//     return;
+//   }
+//   if (!gps_init_)
+//   {
+//     gps_init_ = true;
+//     init_alt_ = msg.altitude;
+//     init_lat_ = msg.latitude;
+//     init_lon_ = msg.longitude;
+//   }
+//   else
+//   {
+//     input_.gps_n = EARTH_RADIUS*(msg.latitude - init_lat_)*M_PI/180.0;
+//     input_.gps_e = EARTH_RADIUS*cos(init_lat_*M_PI/180.0)*(msg.longitude - init_lon_)*M_PI/180.0;
+//     input_.gps_h = msg.altitude - init_alt_;
+//     input_.gps_Vg = msg.speed;
+//     if (msg.speed > 0.3)
+//       input_.gps_course = msg.ground_course;
+//     input_.gps_new = true;
+//   }
+// }
+
+void ins_estimator_base::imuCallback(const sensor_msgs::Imu &msg)
+{
+  input_.accel_x = msg.linear_acceleration.x;
+  input_.accel_y = msg.linear_acceleration.y;
+  input_.accel_z = msg.linear_acceleration.z;
+
+  input_.gyro_x = msg.angular_velocity.x;
+  input_.gyro_y = msg.angular_velocity.y;
+  input_.gyro_z = msg.angular_velocity.z;
+}
+
+void ins_estimator_base::baroAltCallback(const rosflight_msgs::Barometer &msg)
+{
+
+  if (armed_first_time_ && !baro_init_)
+  {
+    if (baro_count_ < 100)
+    {
+      init_static_ += msg.pressure;
+      init_static_vector_.push_back(msg.pressure);
+      input_.static_pres = 0;
+      baro_count_ += 1;
+    }
+    else
+    {
+      init_static_ = std::accumulate(init_static_vector_.begin(), init_static_vector_.end(),
+                                     0.0)/init_static_vector_.size();
+      baro_init_ = true;
+
+      //Check that it got a good calibration.
+      std::sort(init_static_vector_.begin(), init_static_vector_.end());
+      float q1 = (init_static_vector_[24] + init_static_vector_[25])/2.0;
+      float q3 = (init_static_vector_[74] + init_static_vector_[75])/2.0;
+      float IQR = q3 - q1;
+      float upper_bound = q3 + 2.0*IQR;
+      float lower_bound = q1 - 2.0*IQR;
+      for (int i = 0; i < 100; i++)
+      {
+        if (init_static_vector_[i] > upper_bound)
+        {
+          baro_init_ = false;
+          baro_count_ = 0;
+          init_static_vector_.clear();
+          ROS_WARN("Bad baro calibration. Recalibrating");
+          break;
+        }
+        else if (init_static_vector_[i] < lower_bound)
+        {
+          baro_init_ = false;
+          baro_count_ = 0;
+          init_static_vector_.clear();
+          ROS_WARN("Bad baro calibration. Recalibrating");
+          break;
+        }
+      }
+    }
+  }
+  else
+  {
+    float static_pres_old = input_.static_pres;
+    input_.static_pres = -msg.pressure + init_static_;
+
+    float gate_gain = 1.35*params_.rho*params_.gravity;
+    if (input_.static_pres < static_pres_old - gate_gain)
+    {
+      input_.static_pres = static_pres_old - gate_gain;
+    }
+    else if (input_.static_pres > static_pres_old + gate_gain)
+    {
+      input_.static_pres = static_pres_old + gate_gain;
+    }
+  }
+}
+
+void ins_estimator_base::airspeedCallback(const rosflight_msgs::Airspeed &msg)
+{
+  float diff_pres_old = input_.diff_pres;
+  input_.diff_pres = msg.differential_pressure;
+
+  float gate_gain = pow(3, 2)*params_.rho/2.0;
+  if (input_.diff_pres < diff_pres_old - gate_gain)
+  {
+    input_.diff_pres = diff_pres_old - gate_gain;
+  }
+  else if (input_.diff_pres > diff_pres_old + gate_gain)
+  {
+    input_.diff_pres = diff_pres_old + gate_gain;
+  }
+}
+
+void ins_estimator_base::statusCallback(const rosflight_msgs::Status &msg)
+{
+  if (!armed_first_time_ && msg.armed)
+    armed_first_time_ = true;
+}
+
+} //end namespace
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "rosplane_estimator");
+  rosplane::ins_estimator_base *est = new rosplane::ins_estimator_example();
+
+  ros::spin();
+
+  return 0;
+}

--- a/rosplane/src/ins_estimator_example.cpp
+++ b/rosplane/src/ins_estimator_example.cpp
@@ -1,0 +1,416 @@
+#include "ins_estimator_base.h"
+#include "ins_estimator_example.h"
+
+namespace rosplane
+{
+
+float radians(float degrees)
+{
+  return M_PI*degrees/180.0;
+}
+
+ins_estimator_example::ins_estimator_example() :
+  ins_estimator_base(),
+  xhat_a_(Eigen::Vector2f::Zero()),
+  P_a_(Eigen::Matrix2f::Identity()),
+  Q_a_(Eigen::Matrix2f::Identity()),
+  xhat_p_(Eigen::VectorXf::Zero(7)),
+  P_p_(Eigen::MatrixXf::Identity(7, 7)),
+  Q_p_(Eigen::MatrixXf::Identity(7, 7)),
+  R_p_(Eigen::MatrixXf::Zero(7, 7)),
+  f_p_(7),
+  A_p_(7, 7),
+  C_p_(7),
+  L_p_(7)
+{
+  P_a_ *= powf(radians(5.0f), 2);
+
+  Q_a_(0, 0) = 0.00000001;
+  Q_a_(1, 1) = 0.00000001;
+
+  P_p_ = Eigen::MatrixXf::Identity(7, 7);
+  P_p_(0, 0) = .03;
+  P_p_(1, 1) = .03;
+  P_p_(2, 2) = .01;
+  P_p_(3, 3) = radians(5.0f);
+  P_p_(4, 4) = .04;
+  P_p_(5, 5) = .04;
+  P_p_(6, 6) = radians(5.0f);
+
+  Q_p_ *= 0.0001f;
+  Q_p_(3, 3) = 0.000001f;
+
+  phat_ = 0;
+  qhat_ = 0;
+  rhat_ = 0;
+  phihat_ = 0;
+  thetahat_ = 0;
+  psihat_ = 0;
+  Vwhat_ = 0;
+
+  lpf_static_ = 0;
+  lpf_diff_ = 0;
+
+  N_ = 10;
+
+  alpha_ = 0.0f;
+}
+
+void ins_estimator_example::estimate(const params_s &params, const input_s &input, output_s &output)
+{
+  if (alpha_ == 0.0f) //initailze stuff that comes from params
+  {
+    R_accel_ = powf(params.sigma_accel, 2);
+
+    R_p_(0, 0) = powf(params.sigma_n_gps, 2);
+    R_p_(1, 1) = powf(params.sigma_e_gps, 2);
+    R_p_(2, 2) = powf(params.sigma_Vg_gps, 2);
+    R_p_(3, 3) = powf(params.sigma_course_gps, 2);
+    R_p_(4, 4) = 0.001;
+    R_p_(5, 5) = 0.001;
+
+    float lpf_a = 50.0;
+    float lpf_a1 = 8.0;
+    alpha_ = exp(-lpf_a*params.Ts);
+    alpha1_ = exp(-lpf_a1*params.Ts);
+  }
+
+  // low pass filter gyros to estimate angular rates
+  lpf_gyro_x_ = alpha_*lpf_gyro_x_ + (1 - alpha_)*input.gyro_x;
+  lpf_gyro_y_ = alpha_*lpf_gyro_y_ + (1 - alpha_)*input.gyro_y;
+  lpf_gyro_z_ = alpha_*lpf_gyro_z_ + (1 - alpha_)*input.gyro_z;
+
+  float phat = lpf_gyro_x_;
+  float qhat = lpf_gyro_y_;
+  float rhat = lpf_gyro_z_;
+
+  // low pass filter static pressure sensor and invert to esimate altitude
+  lpf_static_ = alpha1_*lpf_static_ + (1 - alpha1_)*input.static_pres;
+  float hhat = lpf_static_/params.rho/params.gravity;
+
+  // low pass filter diff pressure sensor and invert to extimate Va
+  lpf_diff_ = alpha1_*lpf_diff_ + (1 - alpha1_)*input.diff_pres;
+
+  // when the plane isn't moving or moving slowly, the noise in the sensor
+  // will cause the differential pressure to go negative. This will catch
+  // those cases.
+  if (lpf_diff_ <= 0)
+    lpf_diff_ = 0.000001;
+
+  float Vahat = sqrt(2/params.rho*lpf_diff_);
+
+  // low pass filter accelerometers
+  lpf_accel_x_ = alpha_*lpf_accel_x_ + (1 - alpha_)*input.accel_x;
+  lpf_accel_y_ = alpha_*lpf_accel_y_ + (1 - alpha_)*input.accel_y;
+  lpf_accel_z_ = alpha_*lpf_accel_z_ + (1 - alpha_)*input.accel_z;
+
+  // implement continuous-discrete EKF to estimate roll and pitch angles
+  // prediction step
+  float cp; // cos(phi)
+  float sp; // sin(phi)
+  float tt; // tan(thata)
+  float ct; // cos(thata)
+  float st; // sin(theta)
+  for (int i = 0; i < N_; i++)
+  {
+    cp = cosf(xhat_a_(0)); // cos(phi)
+    sp = sinf(xhat_a_(0)); // sin(phi)
+    tt = tanf(xhat_a_(1)); // tan(thata)
+    ct = cosf(xhat_a_(1)); // cos(thata)
+
+    f_a_(0) = phat + (qhat*sp + rhat*cp)*tt;
+    f_a_(1) = qhat*cp - rhat*sp;
+
+    A_a_ = Eigen::Matrix2f::Zero();
+    A_a_(0, 0) = (qhat*cp - rhat*sp)*tt;
+    A_a_(0, 1) = (qhat*sp + rhat*cp)/ct/ct;
+    A_a_(1, 0) = -qhat*sp - rhat*cp;
+
+    xhat_a_ += f_a_*(params.Ts/N_);
+    P_a_ += (A_a_*P_a_ + P_a_*A_a_.transpose() + Q_a_)*(params.Ts/N_);
+  }
+  // measurement updates
+  cp = cosf(xhat_a_(0));
+  sp = sinf(xhat_a_(0));
+  ct = cosf(xhat_a_(1));
+  st = sinf(xhat_a_(1));
+  Eigen::Matrix2f I;
+  I = Eigen::Matrix2f::Identity();
+
+  // x-axis accelerometer
+  h_a_ = qhat*Vahat*st + params.gravity*st;
+  C_a_ = Eigen::Vector2f::Zero();
+  C_a_(1) = qhat*Vahat*ct + params.gravity*ct;
+  L_a_ = (P_a_*C_a_)/(R_accel_ + C_a_.transpose()*P_a_*C_a_);
+  P_a_ = (I - L_a_*C_a_.transpose())*P_a_;
+  xhat_a_ += L_a_*((hhat < 15 ? lpf_accel_x_/3 : lpf_accel_x_) - h_a_);
+
+  // y-axis accelerometer
+  h_a_ = rhat*Vahat*ct - phat*Vahat*st - params.gravity*ct*sp;
+  C_a_ = Eigen::Vector2f::Zero();
+  C_a_(0) = -params.gravity*cp*ct;
+  C_a_(1) = -rhat*Vahat*st - phat*Vahat*ct + params.gravity*st*sp;
+  L_a_ = (P_a_*C_a_)/(R_accel_ + C_a_.transpose()*P_a_*C_a_);
+  P_a_ = (I - L_a_*C_a_.transpose())*P_a_;
+  xhat_a_ += L_a_*(lpf_accel_y_ - h_a_);
+
+  // z-axis accelerometer
+  h_a_ = -qhat*Vahat*ct - params.gravity*ct*cp;
+  C_a_ = Eigen::Vector2f::Zero();
+  C_a_(0) = params.gravity*sp*ct;
+  C_a_(1) = (qhat*Vahat + params.gravity*cp)*st;
+  L_a_ = (P_a_*C_a_)/(R_accel_ + C_a_.transpose()*P_a_*C_a_);
+  P_a_ = (I - L_a_*C_a_.transpose())*P_a_;
+  xhat_a_ += L_a_*(lpf_accel_z_ - h_a_);
+
+  check_xhat_a();
+
+  float phihat = xhat_a_(0);
+  float thetahat = xhat_a_(1);
+
+  // implement continous-discrete EKF to estimate pn, pe, chi, Vg
+  // prediction step
+  float psidot, tmp, Vgdot;
+  if (fabsf(xhat_p_(2)) < 0.01f)
+  {
+    xhat_p_(2) = 0.01; // prevent devide by zero
+  }
+
+  for (int i = 0; i < N_; i++)
+  {
+    psidot = (qhat*sinf(phihat) + rhat*cosf(phihat))/cosf(thetahat);
+    tmp = -psidot*Vahat*(xhat_p_(4)*cosf(xhat_p_(6)) + xhat_p_(5)*sinf(xhat_p_(6)))/xhat_p_(2);
+    Vgdot = ((Vahat*cosf(xhat_p_(6)) + xhat_p_(4))*(-psidot*Vahat*sinf(xhat_p_(6))) + (Vahat*sinf(xhat_p_(
+               6)) + xhat_p_(5))*(psidot*Vahat*cosf(xhat_p_(6))))/xhat_p_(2);
+
+    f_p_ = Eigen::VectorXf::Zero(7);
+    f_p_(0) = xhat_p_(2)*cosf(xhat_p_(3));
+    f_p_(1) = xhat_p_(2)*sinf(xhat_p_(3));
+    f_p_(2) = Vgdot;
+    f_p_(3) = params.gravity/xhat_p_(2)*tanf(phihat)*cosf(xhat_p_(3) - xhat_p_(6));
+    f_p_(6) = psidot;
+
+    A_p_ = Eigen::MatrixXf::Zero(7, 7);
+    A_p_(0, 2) = cos(xhat_p_(3));
+    A_p_(0, 3) = -xhat_p_(2)*sinf(xhat_p_(3));
+    A_p_(1, 2) = sin(xhat_p_(3));
+    A_p_(1, 3) = xhat_p_(2)*cosf(xhat_p_(3));
+    A_p_(2, 2) = -Vgdot/xhat_p_(2);
+    A_p_(2, 4) = -psidot*Vahat*sinf(xhat_p_(6))/xhat_p_(2);
+    A_p_(2, 5) = psidot*Vahat*cosf(xhat_p_(6))/xhat_p_(2);
+    A_p_(2, 6) = tmp;
+    A_p_(3, 2) = -params.gravity/powf(xhat_p_(2), 2)*tanf(phihat)*cosf(xhat_p_(3) - xhat_p_(6));
+    A_p_(3, 3) = -params.gravity/xhat_p_(2)*tanf(phihat)*sinf(xhat_p_(3) - xhat_p_(6));
+    A_p_(3, 6) = params.gravity/xhat_p_(2)*tanf(phihat)*sinf(xhat_p_(3) - xhat_p_(6));
+
+    xhat_p_ += f_p_*(params.Ts/N_);
+    P_p_ += (A_p_*P_p_ + P_p_*A_p_.transpose() + Q_p_)*(params.Ts/N_);
+  }
+
+//    while(xhat_p(3) > radians(180.0f)) xhat_p(3) = xhat_p(3) - radians(360.0f);
+//    while(xhat_p(3) < radians(-180.0f)) xhat_p(3) = xhat_p(3) + radians(360.0f);
+//    if(xhat_p(3) > radians(180.0f) || xhat_p(3) < radians(-180.0f))
+//    {
+//        ROS_WARN("Course estimate not wrapped from -pi to pi");
+//        xhat_p(3) = 0;
+//    }
+
+  // measurement updates
+  if (input.gps_new)
+  {
+    Eigen::MatrixXf I_p(7, 7);
+    I_p = Eigen::MatrixXf::Identity(7, 7);
+
+    // gps North position
+    h_p_ = xhat_p_(0);
+    C_p_ = Eigen::VectorXf::Zero(7);
+    C_p_(0) = 1;
+    L_p_ = (P_p_*C_p_)/(R_p_(0, 0) + (C_p_.transpose()*P_p_*C_p_));
+    P_p_ = (I_p - L_p_*C_p_.transpose())*P_p_;
+    xhat_p_ = xhat_p_ + L_p_*(input.gps_n - h_p_);
+
+    // gps East position
+    h_p_ = xhat_p_(1);
+    C_p_ = Eigen::VectorXf::Zero(7);
+    C_p_(1) = 1;
+    L_p_ = (P_p_*C_p_)/(R_p_(1, 1) + (C_p_.transpose()*P_p_*C_p_));
+    P_p_ = (I_p - L_p_*C_p_.transpose())*P_p_;
+    xhat_p_ = xhat_p_ + L_p_*(input.gps_e - h_p_);
+
+    // gps ground speed
+    h_p_ = xhat_p_(2);
+    C_p_ = Eigen::VectorXf::Zero(7);
+    C_p_(2) = 1;
+    L_p_ = (P_p_*C_p_)/(R_p_(2, 2) + (C_p_.transpose()*P_p_*C_p_));
+    P_p_ = (I_p - L_p_*C_p_.transpose())*P_p_;
+    xhat_p_ = xhat_p_ + L_p_*(input.gps_Vg - h_p_);
+
+    // gps course
+    //wrap course measurement
+    float gps_course = fmodf(input.gps_course, radians(360.0f));
+
+    while (gps_course - xhat_p_(3) > radians(180.0f)) gps_course = gps_course - radians(360.0f);
+    while (gps_course - xhat_p_(3) < radians(-180.0f)) gps_course = gps_course + radians(360.0f);
+    h_p_ = xhat_p_(3);
+    C_p_ = Eigen::VectorXf::Zero(7);
+    C_p_(3) = 1;
+    L_p_ = (P_p_*C_p_)/(R_p_(3, 3) + (C_p_.transpose()*P_p_*C_p_));
+    P_p_ = (I_p - L_p_*C_p_.transpose())*P_p_;
+    xhat_p_ = xhat_p_ + L_p_*(gps_course - h_p_);
+
+//        // pseudo measurement #1 y_1 = Va*cos(psi)+wn-Vg*cos(chi)
+//        h_p = Vahat*cosf(xhat_p(6)) + xhat_p(4) - xhat_p(2)*cosf(xhat_p(3));  // pseudo measurement
+//        C_p = Eigen::VectorXf::Zero(7);
+//        C_p(2) = -cos(xhat_p(3));
+//        C_p(3) = xhat_p(2)*sinf(xhat_p(3));
+//        C_p(4) = 1;
+//        C_p(6) = -Vahat*sinf(xhat_p(6));
+//        L_p = (P_p*C_p)/(R_p(4,4) + (C_p.transpose()*P_p*C_p));
+//        P_p = (I_p - L_p*C_p.transpose())*P_p;
+//        xhat_p = xhat_p + L_p*(0 - h_p);
+
+//        // pseudo measurement #2 y_2 = Va*sin(psi) + we - Vg*sin(chi)
+//        h_p = Vahat*sinf(xhat_p(6))+xhat_p(5)-xhat_p(2)*sinf(xhat_p(3));  // pseudo measurement
+//        C_p = Eigen::VectorXf::Zero(7);
+//        C_p(2) = -sin(xhat_p(3));
+//        C_p(3) = -xhat_p(2)*cosf(xhat_p(3));
+//        C_p(5) = 1;
+//        C_p(6) = Vahat*cosf(xhat_p(6));
+//        L_p = (P_p*C_p)/(R_p(5,5) + (C_p.transpose()*P_p*C_p));
+//        P_p = (I_p - L_p*C_p.transpose())*P_p;
+//        xhat_p = xhat_p + L_p*(0 - h_p);
+
+    if (xhat_p_(0) > 10000 || xhat_p_(0) < -10000)
+    {
+      ROS_WARN("gps n limit reached");
+      xhat_p_(0) = input.gps_n;
+    }
+    if (xhat_p_(1) > 10000 || xhat_p_(1) < -10000)
+    {
+      ROS_WARN("gps e limit reached");
+      xhat_p_(1) = input.gps_e;
+    }
+  }
+
+  bool problem = false;
+  int prob_index;
+  for (int i = 0; i < 7; i++)
+  {
+    if (!std::isfinite(xhat_p_(i)))
+    {
+      if (!problem)
+      {
+        problem = true;
+        prob_index = i;
+      }
+      switch (i)
+      {
+      case 0:
+        xhat_p_(i) = input.gps_n;
+        break;
+      case 1:
+        xhat_p_(i) = input.gps_e;
+        break;
+      case 2:
+        xhat_p_(i) = input.gps_Vg;
+        break;
+      case 3:
+        xhat_p_(i) = input.gps_course;
+        break;
+      case 6:
+        xhat_p_(i) = input.gps_course;
+        break;
+      default:
+        xhat_p_(i) = 0;
+      }
+      P_p_ = Eigen::MatrixXf::Identity(7, 7);
+      P_p_(0, 0) = .03;
+      P_p_(1, 1) = .03;
+      P_p_(2, 2) = .01;
+      P_p_(3, 3) = radians(5.0f);
+      P_p_(4, 4) = .04;
+      P_p_(5, 5) = .04;
+      P_p_(6, 6) = radians(5.0f);
+    }
+  }
+  if (problem)
+  {
+    ROS_WARN("position estimator reinitialized due to non-finite state %d", prob_index);
+  }
+  if (xhat_p_(6) - xhat_p_(3) > radians(360.0f) || xhat_p_(6) - xhat_p_(3) < radians(-360.0f))
+  {
+    //xhat_p(3) = fmodf(xhat_p(3),2.0*M_PI);
+    xhat_p_(6) = fmodf(xhat_p_(6), 2.0*M_PI);
+  }
+
+  float pnhat = xhat_p_(0);
+  float pehat = xhat_p_(1);
+  float Vghat = xhat_p_(2);
+  float chihat = xhat_p_(3);
+  float wnhat = xhat_p_(4);
+  float wehat = xhat_p_(5);
+  float psihat = xhat_p_(6);
+
+  output.pn = pnhat;
+  output.pe = pehat;
+  output.h = hhat;
+  output.Va = Vahat;
+  output.alpha = 0;
+  output.beta = 0;
+  output.phi = phihat;
+  output.theta = thetahat;
+  output.chi = chihat;
+  output.p = phat;
+  output.q = qhat;
+  output.r = rhat;
+  output.Vg = Vghat;
+  output.wn = wnhat;
+  output.we = wehat;
+  output.psi = psihat;
+}
+
+void ins_estimator_example::check_xhat_a()
+{
+  if (xhat_a_(0) > radians(85.0) || xhat_a_(0) < radians(-85.0) || !std::isfinite(xhat_a_(0)))
+  {
+    if (!std::isfinite(xhat_a_(0)))
+    {
+      xhat_a_(0) = 0;
+      P_a_ = Eigen::Matrix2f::Identity();
+      P_a_ *= powf(radians(20.0f), 2);
+      ROS_WARN("attiude estimator reinitialized due to non-finite roll");
+    }
+    else if (xhat_a_(0) > radians(85.0))
+    {
+      xhat_a_(0) = radians(82.0);
+      ROS_WARN("max roll angle");
+    }
+    else if (xhat_a_(0) < radians(-85.0))
+    {
+      xhat_a_(0) = radians(-82.0);
+      ROS_WARN("min roll angle");
+    }
+  }
+  if (xhat_a_(1) > radians(80.0) || xhat_a_(1) < radians(-80.0) || !std::isfinite(xhat_a_(1)))
+  {
+    if (!std::isfinite(xhat_a_(1)))
+    {
+      xhat_a_(1) = 0;
+      P_a_ = Eigen::Matrix2f::Identity();
+      P_a_ *= powf(radians(20.0f), 2);
+      ROS_WARN("attiude estimator reinitialized due to non-finite pitch");
+    }
+    else if (xhat_a_(1) > radians(80.0))
+    {
+      xhat_a_(1) = radians(77.0);
+      ROS_WARN("max pitch angle");
+    }
+    else if (xhat_a_(1) < radians(-80.0))
+    {
+      xhat_a_(1) = radians(-77.0);
+      ROS_WARN("min pitch angle");
+    }
+  }
+}
+
+} //end namespace

--- a/rosplane_sim/params/fixedwing.yaml
+++ b/rosplane_sim/params/fixedwing.yaml
@@ -1,14 +1,14 @@
 # Based on the My Twin Dream airframe (1.8m wingspan)
-mass: 3.92
+mass: 5.7
 
-Jx: 0.213
-Jy: 0.171
-Jz: 0.350
+Jx: 0.386
+Jy: 0.1827
+Jz: 0.56628
 Jxz: 0.04
 
 rho: 1.2682
-wing_s: 0.468
-wing_b: 1.8
+wing_s: 0.4874
+wing_b: 1.9
 wing_c: 0.26
 wing_M: 50
 wing_epsilon: 0.1592
@@ -98,7 +98,7 @@ delta_t0: 0.4
 wind_speed_topic: "gazebo/wind_speed"
 truthTopic: "truth"
 
-# Forces and Moments
+# Forces anI don't think that I understand the limitations of this XFLR model well enough.d Moments
 windSpeedTopic: "wind"
 commandTopic: "command"
 

--- a/rosplane_sim/params/fixedwing.yaml
+++ b/rosplane_sim/params/fixedwing.yaml
@@ -1,14 +1,14 @@
 # Based on the My Twin Dream airframe (1.8m wingspan)
-mass: 5.7
+mass: 3.92
 
-Jx: 0.386
-Jy: 0.1827
-Jz: 0.56628
+Jx: 0.213
+Jy: 0.171
+Jz: 0.350
 Jxz: 0.04
 
 rho: 1.2682
-wing_s: 0.4874
-wing_b: 1.9
+wing_s: 0.468
+wing_b: 1.8
 wing_c: 0.26
 wing_M: 50
 wing_epsilon: 0.1592
@@ -98,7 +98,7 @@ delta_t0: 0.4
 wind_speed_topic: "gazebo/wind_speed"
 truthTopic: "truth"
 
-# Forces anI don't think that I understand the limitations of this XFLR model well enough.d Moments
+# Forces and Moments
 windSpeedTopic: "wind"
 commandTopic: "command"
 


### PR DESCRIPTION
Adds the `ins_estimator` node, which reads inertial sense, baro, and airspeed sensors to create an estimate.

Uses the `lat_ref`, `lon_ref`, and `alt_ref` global parameters, unless private equivalents are provided. Warns if any parameters are missing.